### PR TITLE
feat: Add missing fields in CoinID structs.

### DIFF
--- a/v3/types/types.go
+++ b/v3/types/types.go
@@ -48,8 +48,8 @@ type CoinsID struct {
 	StatusUpdates                *[]StatusUpdateItem `json:"status_updates"`
 	LastUpdated                  string              `json:"last_updated"`
 	Tickers                      *[]TickerItem       `json:"tickers"`
-	Platforms					 map[string]string	 `json:"platforms"`
-	ContractAddress				 string				 `json:"contract_address"`
+	Platforms                    map[string]string   `json:"platforms"`
+	ContractAddress              string              `json:"contract_address"`
 }
 
 // CoinsIDTickers https://api.coingecko.com/api/v3/coins/steem/tickers?page=1

--- a/v3/types/types.go
+++ b/v3/types/types.go
@@ -48,6 +48,8 @@ type CoinsID struct {
 	StatusUpdates                *[]StatusUpdateItem `json:"status_updates"`
 	LastUpdated                  string              `json:"last_updated"`
 	Tickers                      *[]TickerItem       `json:"tickers"`
+	Platforms					 map[string]string	 `json:"platforms"`
+	ContractAddress				 string				 `json:"contract_address"`
 }
 
 // CoinsIDTickers https://api.coingecko.com/api/v3/coins/steem/tickers?page=1


### PR DESCRIPTION
`platforms` and `contract address` fields were missing in the `CoinID` structs.

but the fields are present in response of `/coins/{id}`

You can check the response in api documentation https://www.coingecko.com/en/api/documentation